### PR TITLE
Adding the "Related Products" Section

### DIFF
--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -1594,3 +1594,45 @@ span.form-option-variant.form-option-variant--pattern  {
         border-radius: 3px;
     }
 }
+
+.related {
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
+    width: 100%;
+    img {
+        width: 250px;
+        height: auto;
+    }
+}
+.product-card {
+    min-width: 12rem;
+    width: 20%;
+    height: auto;
+    margin-right: .75rem;
+}
+@media only screen and (max-width: 1024px) {
+    .related {
+        overflow-x: scroll;
+    }
+    .product-card {
+        margin-right: 2rem;
+        min-width: 14rem;
+    }
+}
+@media only screen and (max-width: 414px) {
+    .product-card {
+        min-width: 10rem;
+    }
+}
+@media only screen and (max-width: 375px) {
+    .product-card {
+        margin-right: 1rem;
+        min-width: 10rem;
+    }
+}
+@media only screen and (max-width: 320px) {
+    .product-card {
+        min-width: 16rem;
+    }
+}

--- a/templates/components/products/related.html
+++ b/templates/components/products/related.html
@@ -1,8 +1,8 @@
-<h4>{{lang 'products.related_products' }}</h4>
-<ul class="product-list">
+<h4 class="product-title">{{lang 'products.related_products' }}</h4>
+<div class="product-list related">
     {{#each this}}
-    <li class="product-card">
+    <div class="product-card">
         {{>components/products/card theme_settings=../theme_settings}}
-    </li>
+    </div>
     {{/each}}
-</ul>
+</div>

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -18,6 +18,12 @@ product:
 
     <div itemscope itemtype="http://schema.org/Product">
         {{> components/products/product-view schema=true}}
+
+        {{#if product.related_products }}
+            {{> components/products/related product.related_products}}
+        {{/if}}
+
+
         {{#if product.videos.list.length}}
             {{> components/products/videos product.videos}}
         {{/if}}


### PR DESCRIPTION
### Changes:

- used related.html component and added it to the product.html
- added css to display related products in a flex row and added desktop first media queries to handle overflow
- NOTE: not sure why it only displays 5 products lol


### How it works:

Unless otherwise noted, the related products will be generated automatically.
You can manually set this by:" 
```diff
 1. going to the product page editor in BigCommerce 
 2. going into the "Other Details" tab and unchecking the box that says "Related Products: Find and show related products automatically"
 3. After unchecking, three boxes will appear, one with the list of categories and products and two boxes to add or remove your selected products
 ```